### PR TITLE
Some improvements for the boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 terraform.tfstate*
 .terraform
+backend_config.tf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-ENV TERRAFORM_VERSION=0.10.7
+ENV TERRAFORM_VERSION=0.10.8
 ENV AWSCLI_VERSION=1.11.162
 
 RUN apk add --no-cache --update ca-certificates openssl curl && \

--- a/backend_config.tf
+++ b/backend_config.tf
@@ -1,8 +1,0 @@
-  terraform {
-    backend "s3" {
-    bucket         = "terraform-tfstate-967847953971"
-    key            = "terraform_boilerplate.tfstate"
-    region         = "eu-west-1"
-    dynamodb_table = "terraform_locks"
-  }
-}

--- a/terraform-common.sh
+++ b/terraform-common.sh
@@ -52,7 +52,7 @@ init_terraform_backend() {
 
   ACCOUNT_ID="$(run_awscli sts get-caller-identity --query Account --output text | tr -d '\r')"
   AWS_REGION="eu-west-1"
-  BUCKET_NAME="terraform-tfstate-${ACCOUNT_ID}"
+	BUCKET_NAME="terraform-tfstate-$(echo "${ACCOUNT_ID}" | shasum | cut -f 1 -d " ")"
   DYNAMODB_TABLE="terraform_locks"
 
   echo "Creating bucket ${BUCKET_NAME} and dynamodb table if missing:"
@@ -76,9 +76,9 @@ init_terraform_backend() {
       --provisioned-throughput ReadCapacityUnits=1,WriteCapacityUnits=1
 
   cat <<EOF > "${TF_BACKEND_CONFIG}"
-  terraform {
-    backend "s3" {
-    bucket         = "terraform-tfstate-${ACCOUNT_ID}"
+terraform {
+  backend "s3" {
+    bucket         = "${BUCKET_NAME}"
     key            = "${PROJECT_NAME}.tfstate"
     region         = "${AWS_REGION}"
     dynamodb_table = "${DYNAMODB_TABLE}"


### PR DESCRIPTION
  * Use shasum of account id for bucket-name .This guarantees uniqueness of the bucket name, but also avoids disclosing the id of the account.
  * Use new version of terraform 0.10.8
  * gitignore bucket_config.tf